### PR TITLE
Rename and Update to uPD4990AG

### DIFF
--- a/csv/uPD4990AG.csv
+++ b/csv/uPD4990AG.csv
@@ -1,4 +1,4 @@
-uPD4990,uPD4990_pinout,SOP16,logo_nec.png
+uPD4990AG,uPD4990AG_pinout,SOP16,logo_nec.png
 C2,D,IN
 C1,D,IN
 C0,D,IN


### PR DESCRIPTION
There are two versions used, the DIP 14 pin uPD4990AC and the SOP 16 pin uPD4990AG better to differentiate and add to the wiki